### PR TITLE
29 improve swagger documentation by adding return types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 **/.idea/**/dataSources.local.xml
 **/.idea/**/sqlDataSources.xml
 **/.idea/**/dynamic.xml
+**/.idea/**/aws.xml
 
 # Rider
 # Rider auto-generates .iml files, and contentModel.xml

--- a/TfGM-API-Wrapper/Controllers/ServiceController.cs
+++ b/TfGM-API-Wrapper/Controllers/ServiceController.cs
@@ -35,7 +35,7 @@ public class ServiceController : Controller
     /// <returns>FormattedServices -> Services for the specified stop</returns>
     [Route("/api/services/{stop}")]
     [Produces("application/json")]
-    [SwaggerResponse(StatusCodes.Status200OK)]
+    [SwaggerResponse (type:typeof (FormattedServices), statusCode: StatusCodes.Status200OK)]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid Stop Name or TLAREF provided")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occured")]
     [HttpGet]

--- a/TfGM-API-Wrapper/Controllers/StopsController.cs
+++ b/TfGM-API-Wrapper/Controllers/StopsController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -35,7 +36,7 @@ public class StopsController : Controller
     /// <returns>JSON List -> Stop</returns>
     [Route("/api/stops")]
     [Produces("application/json")]
-    [SwaggerResponse(StatusCodes.Status200OK)]
+    [SwaggerResponse (type:typeof (List<Stop>), statusCode: StatusCodes.Status200OK)]
     [HttpGet]
     public IActionResult GetAllStops()
     {

--- a/TfGM-API-Wrapper/Models/Services/Tram.cs
+++ b/TfGM-API-Wrapper/Models/Services/Tram.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography.Xml;
 
 namespace TfGM_API_Wrapper.Models.Services;
 
@@ -27,11 +28,13 @@ public class Tram
     /// <summary>
     /// Destination for the tram, e.g. Piccadilly.
     /// </summary>
+    /// <example>Piccadilly</example>
     public string Destination { get; }
 
     /// <summary>
     /// Number of carriages the tram has, either 'Single' or 'Double'
     /// </summary>
+    /// <example>Double</example>
     // The carriages could be a good candidate for an enum, but given there are only
     // two possible values, but this may be unnecessary. 
     public string Carriages { get; }
@@ -39,6 +42,7 @@ public class Tram
     /// <summary>
     /// Status of the Tram, e.g. 'Due'
     /// </summary>
+    /// <example>Due</example>
     public string Status { get; }
     
     /// <summary>
@@ -46,6 +50,7 @@ public class Tram
     /// This is stored as a string as this is the format returned by the TfGM API.
     /// It is not converted as no calculations are completed using it.
     /// </summary>
+    /// <example>10</example>
     public string Wait { get; }
 
     /// <summary>


### PR DESCRIPTION
Add return types for both the service request and stop request endpoints.

These now include the schemas for all of the involved types with examples in the generated swagger / swashbuckle documentation