### PR TITLE
Implement basic route planner

### DIFF
--- a/TfGM-API-Wrapper-Tests/Resources/TestRoutePlanner/routes.json
+++ b/TfGM-API-Wrapper-Tests/Resources/TestRoutePlanner/routes.json
@@ -217,7 +217,8 @@
       "Cornbrook",
       "Deansgate - Castlefield",
       "St Peter's Square",
-      "Exchange Square",
+      "Market Street",
+      "Shudehill",
       "Victoria"
     ]
   }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
@@ -217,4 +217,25 @@ public class TestRoutePlanner
         Assert.AreEqual("Didsbury Village", plannedJourney?.StopsFromOrigin.First().StopName);
         Assert.AreEqual("Rochdale Railway Station", plannedJourney?.StopsFromOrigin.Last().StopName);
     }
+
+
+    /// <summary>
+    /// Test to identify a journey between Didsbury and shaw and crompton.
+    /// This should identify that no interchange is required, 
+    /// </summary>
+    [Test]
+    public void TestIdentifyDidsburyShawAndCrompton()
+    {
+        var didsburyStop =  _importedStops?.First(stop => stop.StopName == "East Didsbury");
+        var shawStop =  _importedStops?.First(stop => stop.StopName == "Shaw and Crompton");
+        var plannedJourney = _journeyPlanner?.PlanJourney(didsburyStop, shawStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsFalse(plannedJourney?.RequiresInterchange);
+        Assert.AreEqual(2, plannedJourney?.RoutesFromOrigin.Count);
+        Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Pink"));
+        Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Grey"));
+        Assert.AreEqual(25, plannedJourney?.StopsFromOrigin.Count);
+        Assert.AreEqual("Didsbury Village", plannedJourney?.StopsFromOrigin.First().StopName);
+        Assert.AreEqual("Derker", plannedJourney?.StopsFromOrigin.Last().StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
@@ -126,4 +126,75 @@ public class TestRoutePlanner
         Assert.AreEqual(1, destinationsFromInterchange?.Count);
         
     }
+
+    /// <summary>
+    /// Test to identify the expected route between Altrincham and
+    /// Ashton.
+    /// This should identify Piccadilly as the interchange stop.
+    /// </summary>
+    [Test]
+    public void TestIdentifyAltrinchamAshton()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        var ashtonStop = _importedStops?.First(stop => stop.StopName == "Ashton-Under-Lyne");
+        var plannedJourney = _journeyPlanner?.PlanJourney(altrinchamStop, ashtonStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsTrue(plannedJourney?.RequiresInterchange);
+        var piccadillyStop = _importedStops?.First(stop => stop.StopName == "Piccadilly");
+        Assert.IsNotNull(plannedJourney?.InterchangeStop);
+        Assert.AreEqual(piccadillyStop, plannedJourney?.InterchangeStop);
+        Assert.AreEqual(1, plannedJourney?.RoutesFromOrigin.Count);
+        Assert.AreEqual(1, plannedJourney?.RoutesFromInterchange.Count);
+        Assert.AreEqual(12, plannedJourney?.StopsFromOrigin.Count);
+        Assert.AreEqual(11, plannedJourney?.StopsFromInterchange.Count);
+    }
+
+
+    /// <summary>
+    /// Test to identify a route between Ashton and Altrincham.
+    /// This should identify Cornbrook as the interchange stop.
+    /// There should also be two routes from the interchange stop.
+    /// </summary>
+    [Test]
+    public void TestIdentifyAshtonAltrincham()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        var ashtonStop = _importedStops?.First(stop => stop.StopName == "Ashton-Under-Lyne");
+        var plannedJourney = _journeyPlanner?.PlanJourney(ashtonStop, altrinchamStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsTrue(plannedJourney?.RequiresInterchange);
+        var cornbrookStop = _importedStops?.First(stop => stop.StopName == "Cornbrook");
+        Assert.AreEqual(cornbrookStop, plannedJourney?.InterchangeStop);
+        Assert.AreEqual(1, plannedJourney?.RoutesFromOrigin.Count);
+        Assert.AreEqual(2, plannedJourney?.RoutesFromInterchange.Count);
+        Assert.AreEqual(15, plannedJourney?.StopsFromOrigin.Count);
+        Assert.AreEqual("Ashton West", plannedJourney?.StopsFromOrigin.First().StopName);
+        Assert.AreEqual("Deansgate - Castlefield", plannedJourney?.StopsFromOrigin.Last().StopName);
+        Assert.AreEqual(8, plannedJourney?.StopsFromInterchange.Count);
+        Assert.AreEqual("Trafford Bar", plannedJourney?.StopsFromInterchange.First().StopName);
+        Assert.AreEqual("Navigation Road", plannedJourney?.StopsFromInterchange.Last().StopName);
+    }
+
+    /// <summary>
+    /// Test to identify a route between Ashton and Bury.
+    /// This should identify Piccadilly Gardens as the interchange, and the Yellow line.
+    /// </summary>
+    [Test]
+    public void TestIdentifyAshtonBury()
+    {
+        var ashtonStop = _importedStops?.First(stop => stop.StopName == "Ashton-Under-Lyne");
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var plannedJourney = _journeyPlanner?.PlanJourney(ashtonStop, buryStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsTrue(plannedJourney?.RequiresInterchange);
+        var piccadillyGardensStop = _importedStops?.First(stop => stop.StopName == "Piccadilly Gardens");
+        Assert.AreEqual(piccadillyGardensStop, plannedJourney?.InterchangeStop);
+        Assert.AreEqual(1, plannedJourney?.RoutesFromOrigin.Count);
+        Assert.AreEqual(12, plannedJourney?.StopsFromOrigin.Count);
+        Assert.AreEqual("Ashton West", plannedJourney?.StopsFromOrigin.First().StopName);
+        Assert.AreEqual("Piccadilly", plannedJourney?.StopsFromOrigin.Last().StopName);
+        Assert.AreEqual(12, plannedJourney?.StopsFromInterchange.Count);
+        Assert.AreEqual("Market Street", plannedJourney?.StopsFromInterchange.First().StopName);
+        Assert.AreEqual("Radcliffe", plannedJourney?.StopsFromInterchange.Last().StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
@@ -98,4 +98,32 @@ public class TestRoutePlanner
         Assert.IsTrue(plannedJourney?.RoutesFromInterchange.Any(route => route.Name == "Green"));
         Assert.IsTrue(plannedJourney?.RoutesFromInterchange.Any(route => route.Name == "Yellow"));
     }
+    
+    /// <summary>
+    /// Test to identify a route between the airport and bury.
+    /// This should include the expected stops before and after the interchange.
+    /// </summary>
+    [Test]
+    public void TestIdentifyJourneyAirportBuryStops()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var plannedJourney = _journeyPlanner?.PlanJourney(airportStop, buryStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsNotNull(plannedJourney?.StopsFromOrigin);
+        Assert.IsNotNull(plannedJourney?.StopsFromInterchange);
+        Assert.IsNotNull(plannedJourney?.InterchangeStop);
+        Assert.IsTrue(plannedJourney?.RequiresInterchange);
+        var victoriaStop = _importedStops?.First(stop => stop.StopName == "Victoria");
+        Assert.AreEqual(victoriaStop, plannedJourney?.InterchangeStop);
+        var originStops = plannedJourney?.StopsFromOrigin;
+        var interchangeStops = plannedJourney?.StopsFromInterchange;
+        Assert.AreEqual(23, originStops?.Count);
+        Assert.AreEqual(9, interchangeStops?.Count);
+        var destinationsFromOrigin = plannedJourney?.TerminiFromOrigin;
+        var destinationsFromInterchange = plannedJourney?.TerminiFromInterchange;
+        Assert.AreEqual(1, destinationsFromOrigin?.Count);
+        Assert.AreEqual(1, destinationsFromInterchange?.Count);
+        
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
@@ -197,4 +197,24 @@ public class TestRoutePlanner
         Assert.AreEqual("Market Street", plannedJourney?.StopsFromInterchange.First().StopName);
         Assert.AreEqual("Radcliffe", plannedJourney?.StopsFromInterchange.Last().StopName);
     }
+
+    /// <summary>
+    /// Test to identify a route between Didsbury and Rochdale.
+    /// This should identify an interchange is not required,
+    /// and there is only one possible route.
+    /// </summary>
+    [Test]
+    public void TestIdentifyDidsburyRochdale()
+    {
+        var didsburyStop =  _importedStops?.First(stop => stop.StopName == "East Didsbury");
+        var rochdaleStop = _importedStops?.First(stop => stop.StopName == "Rochdale Town Centre");
+        var plannedJourney = _journeyPlanner?.PlanJourney(didsburyStop, rochdaleStop);
+        Assert.IsNotNull(plannedJourney);
+        Assert.IsFalse(plannedJourney?.RequiresInterchange);
+        Assert.AreEqual(1, plannedJourney?.RoutesFromOrigin.Count);
+        Assert.AreEqual("Pink", plannedJourney?.RoutesFromOrigin.First().Name);
+        Assert.AreEqual(31, plannedJourney?.StopsFromOrigin.Count);
+        Assert.AreEqual("Didsbury Village", plannedJourney?.StopsFromOrigin.First().StopName);
+        Assert.AreEqual("Rochdale Railway Station", plannedJourney?.StopsFromOrigin.Last().StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyPlanner.cs
@@ -23,7 +23,7 @@ public class TestRoutePlanner
     private List<Stop>? _importedStops;
     private RouteLoader? _routeLoader;
     private List<Route>? _routes;
-    private JourneyPlanner? _routePlanner;
+    private JourneyPlanner? _journeyPlanner;
     
     /// <summary>
     /// Sets up the required resources for testing route planning,
@@ -47,7 +47,7 @@ public class TestRoutePlanner
 
         _routeLoader = new RouteLoader(_validResourcesConfig, _importedStops);
         _routes = _routeLoader.ImportRoutes();
-        _routePlanner = new JourneyPlanner(_routes);
+        _journeyPlanner = new JourneyPlanner(_routes);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class TestRoutePlanner
     {
         var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
         var saleStop = _importedStops?.First(stop => stop.StopName == "Sale");
-        var plannedJourney = _routePlanner?.PlanJourney(altrinchamStop, saleStop);
+        var plannedJourney = _journeyPlanner?.PlanJourney(altrinchamStop, saleStop);
         //Should be two possible routes from the origin, purple and green
        Assert.IsNotNull(plannedJourney);
        Assert.IsFalse(plannedJourney?.RequiresInterchange);
@@ -78,5 +78,24 @@ public class TestRoutePlanner
        Assert.AreEqual(2, plannedJourney?.RoutesFromOrigin.Count);
        Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Green"));
        Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Purple"));
+    }
+
+
+    /// <summary>
+    /// Test to identify a route where an interchange is required.
+    /// This should be true.
+    /// </summary>
+    [Test]
+    public void TestPlanRouteInterchangeRequired()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var plannedJourney = _journeyPlanner?.PlanJourney(airportStop, buryStop);
+        Assert.NotNull(plannedJourney);
+        Assert.IsTrue(plannedJourney?.RequiresInterchange);
+        Assert.IsNotNull(plannedJourney?.RoutesFromInterchange);
+        Assert.AreEqual(2, plannedJourney?.RoutesFromInterchange.Count);
+        Assert.IsTrue(plannedJourney?.RoutesFromInterchange.Any(route => route.Name == "Green"));
+        Assert.IsTrue(plannedJourney?.RoutesFromInterchange.Any(route => route.Name == "Yellow"));
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using TfGM_API_Wrapper.Models.Resources;
 using TfGM_API_Wrapper.Models.RoutePlanner;
 using TfGM_API_Wrapper.Models.Stops;
@@ -136,5 +137,34 @@ public class TestRouteIdentifier
         var interchangeStop = _routeIdentifier?.IdentifyInterchangeStop(altrinchamStop, ashtonStop);
         Assert.NotNull(interchangeStop);
         Assert.AreEqual("Piccadilly", interchangeStop?.StopName);
+    }
+
+    
+    /// <summary>
+    /// Test to identify the interchange between Eccles and the Trafford Centre.
+    /// This should return Pomona.
+    /// </summary>
+    [Test]
+    public void TestIdentifyEcclesTraffordCentreInterchange()
+    {
+        var ecclesStop = _importedStops?.First(stop => stop.StopName == "Eccles");
+        var traffordStop = _importedStops?.First(stop => stop.StopName == "The Trafford Centre");
+        var interchangeStop = _routeIdentifier?.IdentifyInterchangeStop(ecclesStop, traffordStop);
+        Assert.IsNotNull(interchangeStop);
+        Assert.AreEqual("Pomona", interchangeStop?.StopName);
+    }
+
+    /// <summary>
+    /// Test to identify the interchange between the Airport and Bury.
+    /// This should return Victoria.
+    /// </summary>
+    [Test]
+    public void TestIdentifyInterchangeAirportBury()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var interchangeStop = _routeIdentifier?.IdentifyInterchangeStop(airportStop, buryStop);
+        Assert.IsNotNull(interchangeStop);
+        Assert.AreEqual("Victoria", interchangeStop?.StopName);
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -426,4 +426,22 @@ public class TestRouteIdentifier
                     .IdentifyIntermediateStops(stretfordStop, null, purpleRoute);
             });
     }
+    
+    /// <summary>
+    /// Test to identify intermediate stops with a null route.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateRouteNullRoute()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'route')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyIntermediateStops(stretfordStop, brooklandsStop, null);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -327,4 +327,28 @@ public class TestRouteIdentifier
             intermediateStops.First(stop => stop.StopName == "Sale"))
         );
     }
+
+    /// <summary>
+    /// Test to identify the same intermediate stops as the previous test,
+    /// but as the origin and destination have been swapped, they should be in the
+    /// opposite order.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateStopsReverse()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        var intermediateStops = _routeIdentifier?
+            .IdentifyIntermediateStops(brooklandsStop, stretfordStop, purpleRoute);
+        Assert.IsNotNull(intermediateStops);
+        Assert.IsNotEmpty(intermediateStops!);
+        Assert.AreEqual(2, intermediateStops?.Count);
+        Assert.AreEqual(1, intermediateStops?.IndexOf(
+            intermediateStops.First(stop => stop.StopName == "Dane Road"))
+        );
+        Assert.AreEqual(0, intermediateStops?.IndexOf(
+            intermediateStops.First(stop => stop.StopName == "Sale"))
+        );
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -78,7 +79,8 @@ public class TestRouteIdentifier
     }
 
     /// <summary>
-    /// Test to see if an interchange is required by checking 
+    /// Test to see if an interchange is required by checking stops on different routes.
+    /// This should return true
     /// </summary>
     [Test]
     public void TestInterchangeShouldBeRequired()
@@ -86,5 +88,22 @@ public class TestRouteIdentifier
         var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
         var ashtonStop = _importedStops?.First(stop => stop.StopName == "Ashton Moss");
         Assert.IsTrue(_routeIdentifier?.IsInterchangeRequired(altrinchamStop, ashtonStop));
+    }
+
+    /// <summary>
+    /// Test to determine if a null origin stop
+    /// requires an interchange to a valid dest.
+    /// This should throw an illegal args exception
+    /// </summary>
+    [Test]
+    public void TestInterchangeNullOrigin()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'origin')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IsInterchangeRequired(null, altrinchamStop);
+            });
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -302,4 +302,29 @@ public class TestRouteIdentifier
         Assert.AreEqual(1, intermediateStops?.Count);
         Assert.IsTrue(intermediateStops?.Any(stop => stop.StopName == "Navigation Road"));
     }
+
+    /// <summary>
+    /// Test to identify intermediate stops for a different journey.
+    /// This should return the stops between Stretford and Brooklands
+    /// starting with Dane Road.
+    /// This should match the order they would be traversed in if travelled between.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateStopsDifferentRoute()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        var intermediateStops = _routeIdentifier?
+            .IdentifyIntermediateStops(stretfordStop, brooklandsStop, purpleRoute);
+        Assert.IsNotNull(intermediateStops);
+        Assert.IsNotEmpty(intermediateStops!);
+        Assert.AreEqual(2, intermediateStops?.Count);
+        Assert.AreEqual(0, intermediateStops?.IndexOf(
+            intermediateStops.First(stop => stop.StopName == "Dane Road"))
+        );
+        Assert.AreEqual(1, intermediateStops?.IndexOf(
+            intermediateStops.First(stop => stop.StopName == "Sale"))
+        );
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -252,6 +252,10 @@ public class TestRouteIdentifier
     }
 
 
+    /// <summary>
+    /// Identify routes with a null origin.
+    /// This should throw a null args exception.
+    /// </summary>
     [Test]
     public void TestIdentifyRoutesBetweenNullOrigin()
     {
@@ -261,6 +265,22 @@ public class TestRouteIdentifier
             delegate
             {
                 var unused = _routeIdentifier?.IdentifyRoutesBetween(null, buryStop);
+            });
+    }
+
+    /// <summary>
+    /// Identify the routes between stops with a null destination.
+    /// This should throw a null args exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyRoutesBetweenNullDestination()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'destination')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IdentifyRoutesBetween(buryStop, null);
             });
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -106,4 +106,21 @@ public class TestRouteIdentifier
                 var unused = _routeIdentifier?.IsInterchangeRequired(null, altrinchamStop);
             });
     }
+
+    /// <summary>
+    /// Test to determine if an interchange is required between a valid origin stop
+    /// and a null dest.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestInterchangeNullDest()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'destination')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IsInterchangeRequired(altrinchamStop, null);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -214,4 +214,22 @@ public class TestRouteIdentifier
                 var unused = _routeIdentifier?.IdentifyInterchangeStop(airportStop, null);
             });
     }
+
+    /// <summary>
+    /// Test to Identify the routes between two stops.
+    /// This should contain 2 items, Purple and Green
+    /// </summary>
+    [Test]
+    public void TestIdentifyRoutesBetweenStops()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        var cornbrookStop = _importedStops?.First(stop => stop.StopName == "Cornbrook");
+
+        var identifiedRoutes = _routeIdentifier?.IdentifyRoutesBetween(altrinchamStop, cornbrookStop);
+        Assert.IsNotNull(identifiedRoutes);
+        Assert.IsNotEmpty(identifiedRoutes ?? new List<Route>());
+        Assert.AreEqual(2, identifiedRoutes?.Count);
+        Assert.That(identifiedRoutes!.Any(route => route.Name == "Purple"));
+        Assert.That(identifiedRoutes!.Any(route => route.Name == "Green"));
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -123,4 +123,18 @@ public class TestRouteIdentifier
                 var unused = _routeIdentifier?.IsInterchangeRequired(altrinchamStop, null);
             });
     }
+
+    /// <summary>
+    /// Test to identify an interchange stop for a journey where an interchange is required.
+    /// This should identify the stop shared on both routes that is closest to the destination.
+    /// </summary>
+    [Test]
+    public void TestIdentifyInterChange()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        var ashtonStop = _importedStops?.First(stop => stop.StopName == "Ashton Moss");
+        var interchangeStop = _routeIdentifier?.IdentifyInterchangeStop(altrinchamStop, ashtonStop);
+        Assert.NotNull(interchangeStop);
+        Assert.AreEqual("Piccadilly", interchangeStop?.StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -234,6 +234,10 @@ public class TestRouteIdentifier
     }
 
 
+    /// <summary>
+    /// Test to identify the routes between Bury and Market Street.
+    /// This should identify the green and yellow route.
+    /// </summary>
     [Test]
     public void TestIdentifyRoutesBetweenBuryMarketStreet()
     {
@@ -245,5 +249,18 @@ public class TestRouteIdentifier
         Assert.AreEqual(2, identifiedRoutes?.Count);
         Assert.That(identifiedRoutes!.Any(route => route.Name == "Green"));
         Assert.That(identifiedRoutes!.Any(route => route.Name == "Yellow"));
+    }
+
+
+    [Test]
+    public void TestIdentifyRoutesBetweenNullOrigin()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'origin')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IdentifyRoutesBetween(null, buryStop);
+            });
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -283,4 +283,23 @@ public class TestRouteIdentifier
                 var unused = _routeIdentifier?.IdentifyRoutesBetween(buryStop, null);
             });
     }
+
+    /// <summary>
+    /// Test to identify the stops between an
+    /// origin and a destination on a given route.
+    /// This should identify a single stop, and not include the origin or destination Stop.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateStops()
+    {
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        var timperleyStop = _importedStops?.First(stop => stop.StopName == "Timperley");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        var intermediateStops = _routeIdentifier?
+            .IdentifyIntermediateStops(altrinchamStop, timperleyStop, purpleRoute);
+        Assert.IsNotNull(intermediateStops);
+        Assert.IsNotEmpty(intermediateStops!);
+        Assert.AreEqual(1, intermediateStops?.Count);
+        Assert.IsTrue(intermediateStops?.Any(stop => stop.StopName == "Navigation Road"));
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -232,4 +232,18 @@ public class TestRouteIdentifier
         Assert.That(identifiedRoutes!.Any(route => route.Name == "Purple"));
         Assert.That(identifiedRoutes!.Any(route => route.Name == "Green"));
     }
+
+
+    [Test]
+    public void TestIdentifyRoutesBetweenBuryMarketStreet()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var marketStreetStop = _importedStops?.First(stop => stop.StopName == "Market Street");
+        var identifiedRoutes = _routeIdentifier?.IdentifyRoutesBetween(buryStop, marketStreetStop);
+        Assert.IsNotNull(identifiedRoutes);
+        Assert.IsNotEmpty(identifiedRoutes ?? new List<Route>());
+        Assert.AreEqual(2, identifiedRoutes?.Count);
+        Assert.That(identifiedRoutes!.Any(route => route.Name == "Green"));
+        Assert.That(identifiedRoutes!.Any(route => route.Name == "Yellow"));
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -444,4 +444,22 @@ public class TestRouteIdentifier
                     .IdentifyIntermediateStops(stretfordStop, brooklandsStop, null);
             });
     }
+
+    /// <summary>
+    /// Test to identify the terminus stop of a tram.
+    /// This should return the stop not where the route ends, but the
+    /// route terminates in the direction of travel.
+    /// </summary>
+    [Test]
+    public void TestIdentifyTramTerminusForRoute()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        var identifiedTerminus = _routeIdentifier?
+            .IdentifyRouteTerminus(stretfordStop, brooklandsStop, purpleRoute);
+        var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
+        Assert.IsNotNull(identifiedTerminus);
+        Assert.AreEqual("Altrincham", identifiedTerminus?.StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -408,4 +408,22 @@ public class TestRouteIdentifier
                     .IdentifyIntermediateStops(null, stretfordStop, purpleRoute);
             });
     }
+    
+    /// <summary>
+    /// Test to identify intermediate stops with a null destination.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateRouteNullDestination()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'destination')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyIntermediateStops(stretfordStop, null, purpleRoute);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -167,4 +167,19 @@ public class TestRouteIdentifier
         Assert.IsNotNull(interchangeStop);
         Assert.AreEqual("Victoria", interchangeStop?.StopName);
     }
+
+
+    /// <summary>
+    /// Test to identify the interchange between the Airport and East Didsbury.
+    /// This should be St Werburgh's Road.
+    /// </summary>
+    [Test]
+    public void TestIdentifyInterchangeAirportDidsbury()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        var didsburyStop = _importedStops?.First(stop => stop.StopName == "East Didsbury");
+        var interchangeStop = _routeIdentifier?.IdentifyInterchangeStop(airportStop, didsburyStop);
+        Assert.IsNotNull(interchangeStop);
+        Assert.AreEqual("St Werburgh's Road", interchangeStop?.StopName);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -537,4 +537,24 @@ public class TestRouteIdentifier
                     .IdentifyRouteTerminus(brooklandsStop, stretfordStop, null);
             });
     }
+
+    /// <summary>
+    /// Test to identify a terminus of a route when the origin
+    /// stop does not belong to the route.
+    /// This should throw an invalid operation exception. 
+    /// </summary>
+    [Test]
+    public void TestIdentifyTerminusOriginNotOnRoute()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<InvalidOperationException>()
+                .And.Message.EqualTo("Bury does not exist on Purple route"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyRouteTerminus( buryStop, brooklandsStop, purpleRoute);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -390,4 +390,22 @@ public class TestRouteIdentifier
                     .IdentifyIntermediateStops(stretfordStop, buryStop, purpleRoute);
             });
     }
+
+    /// <summary>
+    /// Test to identify intermediate stops with a null origin.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateRouteNullOrigin()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'origin')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyIntermediateStops(null, stretfordStop, purpleRoute);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -482,4 +482,59 @@ public class TestRouteIdentifier
         Assert.AreEqual("Piccadilly", identifiedTerminus?.StopName);
         Assert.AreEqual(piccadillyStop, identifiedTerminus);
     }
+
+
+    /// <summary>
+    /// Test to identify a terminus with a null origin stop.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyTerminusNullOrigin()
+    {
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'origin')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyRouteTerminus(null, brooklandsStop, purpleRoute);
+            });
+    }
+    
+    /// <summary>
+    /// Identify terminus with a null destination.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyTerminusNullDestination()
+    {
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'destination')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyRouteTerminus(brooklandsStop, null, purpleRoute);
+            });
+    }
+    
+    /// <summary>
+    /// Test to identify a terminus with a null route.
+    /// This should throw an args null exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyTerminusNullRoute()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'route')"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyRouteTerminus(brooklandsStop, stretfordStop, null);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -557,4 +557,24 @@ public class TestRouteIdentifier
                     .IdentifyRouteTerminus( buryStop, brooklandsStop, purpleRoute);
             });
     }
+    
+    /// <summary>
+    /// Test to identify a terminus of a route when the destination
+    /// stop is not on the route
+    /// This should throw an invalid operation exception. 
+    /// </summary>
+    [Test]
+    public void TestIdentifyTerminusDestinationNotOnRoute()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<InvalidOperationException>()
+                .And.Message.EqualTo("Bury does not exist on Purple route"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyRouteTerminus( brooklandsStop, buryStop, purpleRoute);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -351,4 +351,23 @@ public class TestRouteIdentifier
             intermediateStops.First(stop => stop.StopName == "Sale"))
         );
     }
+
+    /// <summary>
+    /// Test to identify an intermediate stops with an origin Stop not on the route.
+    /// This should throw an InvalidOperationException.
+    /// </summary>
+    [Test]
+    public void TestToIdentifyIntermediateStopsWithInvalidStop()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<InvalidOperationException>()
+                .And.Message.EqualTo("Bury does not exist on Purple route"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyIntermediateStops(buryStop, stretfordStop, purpleRoute);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -461,5 +461,25 @@ public class TestRouteIdentifier
         var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
         Assert.IsNotNull(identifiedTerminus);
         Assert.AreEqual("Altrincham", identifiedTerminus?.StopName);
+        Assert.AreEqual(altrinchamStop, identifiedTerminus);
+    }
+
+    /// <summary>
+    /// Test to identify the terminus of the purple route when going in the
+    /// opposite direction.
+    /// This should return Piccadilly. 
+    /// </summary>
+    [Test]
+    public void TestIdentifyTramTerminusForReverseRoute()
+    {
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var brooklandsStop = _importedStops?.First(stop => stop.StopName == "Brooklands");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        var identifiedTerminus = _routeIdentifier?
+            .IdentifyRouteTerminus(brooklandsStop, stretfordStop, purpleRoute);
+        var piccadillyStop = _importedStops?.First(stop => stop.StopName == "Piccadilly");
+        Assert.IsNotNull(identifiedTerminus);
+        Assert.AreEqual("Piccadilly", identifiedTerminus?.StopName);
+        Assert.AreEqual(piccadillyStop, identifiedTerminus);
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -357,7 +357,7 @@ public class TestRouteIdentifier
     /// This should throw an InvalidOperationException.
     /// </summary>
     [Test]
-    public void TestToIdentifyIntermediateStopsWithInvalidStop()
+    public void TestIdentifyIntermediateStopsWithInvalidStop()
     {
         var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
         var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
@@ -368,6 +368,26 @@ public class TestRouteIdentifier
             {
                 var unused = _routeIdentifier?
                     .IdentifyIntermediateStops(buryStop, stretfordStop, purpleRoute);
+            });
+    }
+
+    /// <summary>
+    /// Test to identify intermediate stops where the destination stop
+    /// does not belong to the route.
+    /// This should throw an invalid op exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyIntermediateStopsWithInvalidDestinationStop()
+    {
+        var buryStop = _importedStops?.First(stop => stop.StopName == "Bury");
+        var stretfordStop = _importedStops?.First(stop => stop.StopName == "Stretford");
+        var purpleRoute = _routes?.First(route => route.Name == "Purple");
+        Assert.Throws(Is.TypeOf<InvalidOperationException>()
+                .And.Message.EqualTo("Bury does not exist on Purple route"),
+            delegate
+            {
+                var unused = _routeIdentifier?
+                    .IdentifyIntermediateStops(stretfordStop, buryStop, purpleRoute);
             });
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -198,4 +198,20 @@ public class TestRouteIdentifier
                 var unused = _routeIdentifier?.IdentifyInterchangeStop(null, airportStop);
             });
     }
+
+    /// <summary>
+    /// Test to identify an interchange for a journey with a null destination.
+    /// This should throw a null args exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyInterchangeNullDestination()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'destination')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IdentifyInterchangeStop(airportStop, null);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRouteIdentifier.cs
@@ -182,4 +182,20 @@ public class TestRouteIdentifier
         Assert.IsNotNull(interchangeStop);
         Assert.AreEqual("St Werburgh's Road", interchangeStop?.StopName);
     }
+
+    /// <summary>
+    /// Test to identify the interchange with a null origin.
+    /// This should throw a null args exception.
+    /// </summary>
+    [Test]
+    public void TestIdentifyInterchangeNullOrigin()
+    {
+        var airportStop = _importedStops?.First(stop => stop.StopName == "Manchester Airport");
+        Assert.Throws(Is.TypeOf<ArgumentNullException>()
+                .And.Message.EqualTo("Value cannot be null. (Parameter 'origin')"),
+            delegate
+            {
+                var unused = _routeIdentifier?.IdentifyInterchangeStop(null, airportStop);
+            });
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRoutePlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRoutePlanner.cs
@@ -23,7 +23,7 @@ public class TestRoutePlanner
     private List<Stop>? _importedStops;
     private RouteLoader? _routeLoader;
     private List<Route>? _routes;
-    private RoutePlanner? _routePlanner;
+    private JourneyPlanner? _routePlanner;
     
     /// <summary>
     /// Sets up the required resources for testing route planning,
@@ -47,7 +47,7 @@ public class TestRoutePlanner
 
         _routeLoader = new RouteLoader(_validResourcesConfig, _importedStops);
         _routes = _routeLoader.ImportRoutes();
-        _routePlanner = new RoutePlanner(_routes);
+        _routePlanner = new JourneyPlanner(_routes);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class TestRoutePlanner
     {
         var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
         var saleStop = _importedStops?.First(stop => stop.StopName == "Sale");
-        var plannedJourney = _routePlanner?.FindRoute(altrinchamStop, saleStop);
+        var plannedJourney = _routePlanner?.PlanJourney(altrinchamStop, saleStop);
         //Should be two possible routes from the origin, purple and green
        Assert.IsNotNull(plannedJourney);
        Assert.IsFalse(plannedJourney?.RequiresInterchange);

--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRoutePlanner.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestRoutePlanner.cs
@@ -23,6 +23,7 @@ public class TestRoutePlanner
     private List<Stop>? _importedStops;
     private RouteLoader? _routeLoader;
     private List<Route>? _routes;
+    private RoutePlanner? _routePlanner;
     
     /// <summary>
     /// Sets up the required resources for testing route planning,
@@ -46,6 +47,7 @@ public class TestRoutePlanner
 
         _routeLoader = new RouteLoader(_validResourcesConfig, _importedStops);
         _routes = _routeLoader.ImportRoutes();
+        _routePlanner = new RoutePlanner(_routes);
     }
 
     /// <summary>
@@ -59,27 +61,22 @@ public class TestRoutePlanner
 
     /// <summary>
     /// Test to plan a route on a single line between Altrincham and Sale
-    /// This should return a planned route POCO with the expected origin and destination stops
+    /// This should return a planned route POCO with the expected origin and destination stops.
+    /// This should return that the journey does not require an interchange
+    /// and has two possible routes from the origin.
     /// </summary>
     [Test]
     public void TestIdentifyRouteOnSameLine()
     {
-        Assert.Pass();
-        //This test case has already started being developed, but will 
-        //need to wait until other sections of the route planning have been developed.
         var altrinchamStop = _importedStops?.First(stop => stop.StopName == "Altrincham");
         var saleStop = _importedStops?.First(stop => stop.StopName == "Sale");
-        var routePlanner = new RoutePlanner(_routes);
-        var plannedRoutes = routePlanner.FindRoute(altrinchamStop, saleStop);
-        //Should be two possible routes, one using purple, one using green.
-        Assert.IsNotNull(plannedRoutes);
-        Assert.IsNotEmpty(plannedRoutes);
-        Assert.AreEqual(2, plannedRoutes.Count);
-        var firstRoute = plannedRoutes[0];
-        var secondRoute = plannedRoutes[1];
-        Assert.IsNotNull(firstRoute);
-        Assert.IsNotNull(secondRoute);
-        Assert.AreEqual(altrinchamStop, firstRoute.OriginStop);
-        Assert.AreEqual(altrinchamStop, secondRoute.DestinationStop);
+        var plannedJourney = _routePlanner?.FindRoute(altrinchamStop, saleStop);
+        //Should be two possible routes from the origin, purple and green
+       Assert.IsNotNull(plannedJourney);
+       Assert.IsFalse(plannedJourney?.RequiresInterchange);
+       Assert.IsNotNull(plannedJourney?.RoutesFromOrigin);
+       Assert.AreEqual(2, plannedJourney?.RoutesFromOrigin.Count);
+       Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Green"));
+       Assert.IsTrue(plannedJourney?.RoutesFromOrigin.Any(route => route.Name == "Purple"));
     }
 }

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ashton/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Brooklands/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Castlefield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cornbrook/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deansgate/@EntryIndexedValue">True</s:Boolean>
@@ -7,6 +8,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=metrolink/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naptan/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Stretford/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timperley/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werburgh_0027s/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Brooklands/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Castlefield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cornbrook/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Crompton/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deansgate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Didsbury/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -7,5 +7,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=metrolink/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naptan/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timperley/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werburgh_0027s/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=metrolink/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naptan/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rochdale/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Stretford/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timperley/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean>

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -1,7 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ashton/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Castlefield/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cornbrook/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deansgate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Didsbury/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=metrolink/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naptan/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Werburgh_0027s/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TfGM-API-Wrapper.sln.DotSettings
+++ b/TfGM-API-Wrapper.sln.DotSettings
@@ -2,5 +2,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ashton/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Castlefield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deansgate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eccles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naptan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tlaref/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
+++ b/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
@@ -80,9 +80,9 @@ and destination stops.
 ---
 + RouteIdentifier(List<Route> routes)
 ---
-+ IdentifySingleRoute(Stop origin, Stop destination): List<Route>
 + IdentifyInterchangeStop(Stop origin, Stop destination): Stop
-+ IdentifyInterchangeRoutes(Stop origin, Stop destination, Stop interchange): List<Route> 
++ IdentifyRoutesBetween(Stop origin, Stop destination): List<Route>
++ IdentifyStopsBetween(Stop origin, Stop destination, Route route): List<Stop>
 + IsInterchangeRequired(Stop origin, Stop destination): bool
 }
 

--- a/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
+++ b/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
@@ -67,7 +67,7 @@ Thrown when a route between two stops
 cannot be generated
 }
 
-interface Models.RoutePlanner.IRoutePlanner #Purple {
+interface Models.RoutePlanner.IJourneyPlanner #Purple {
 Interface needed to be implemented for a 
 route planner. 
 ---
@@ -87,12 +87,12 @@ and destination stops.
 }
 
 
-class Models.RoutePlanner.RoutePlanner #Purple {
-Identifies a route between two stops
+class Models.RoutePlanner.JourneyPlanner #Purple {
+Identifies a journey between two stops
 ---
 + RoutePlanner(List<Route> routes)
 ---
-+ FindRoute(Stop origin, Stop destination): List<PlannedRoute>
++ PlanJourney(Stop origin, Stop destination): List<PlannedRoute>
 }
 
 'Models.Services' 

--- a/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
+++ b/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
@@ -84,6 +84,7 @@ and destination stops.
 + IdentifyRoutesBetween(Stop origin, Stop destination): List<Route>
 + IdentifyIntermediateStops(Stop origin, Stop destination, Route route): List<Stop>
 + IsInterchangeRequired(Stop origin, Stop destination): bool
++ IdentifyRouteTerminus(Stop origin, Stop destination, Route route): Stop
 }
 
 

--- a/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
+++ b/TfGM-API-Wrapper/Documentation/TfGM-API-Wraper.puml
@@ -82,7 +82,7 @@ and destination stops.
 ---
 + IdentifyInterchangeStop(Stop origin, Stop destination): Stop
 + IdentifyRoutesBetween(Stop origin, Stop destination): List<Route>
-+ IdentifyStopsBetween(Stop origin, Stop destination, Route route): List<Stop>
++ IdentifyIntermediateStops(Stop origin, Stop destination, Route route): List<Stop>
 + IsInterchangeRequired(Stop origin, Stop destination): bool
 }
 

--- a/TfGM-API-Wrapper/Models/RoutePlanner/IJourneyPlanner.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/IJourneyPlanner.cs
@@ -6,7 +6,7 @@ namespace TfGM_API_Wrapper.Models.RoutePlanner;
 /// <summary>
 /// Interface that needs to be implemented for any RoutePlanner classes.
 /// </summary>
-public interface IRoutePlanner
+public interface IJourneyPlanner
 {
     /// <summary>
     /// Finds a route between an Origin and Destination Stop.
@@ -14,5 +14,5 @@ public interface IRoutePlanner
     /// <param name="origin">Start of journey Stop</param>
     /// <param name="destination">End of journey Stop</param>
     /// <returns></returns>
-    public List<PlannedRoute> FindRoute(Stop origin, Stop destination);
+    public PlannedJourney PlanJourney(Stop origin, Stop destination);
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
@@ -9,8 +9,7 @@ namespace TfGM_API_Wrapper.Models.RoutePlanner;
 /// </summary>
 public class JourneyPlanner : IJourneyPlanner
 {
-    private List<Route> _routes;
-    private RouteIdentifier _routeIdentifier;
+    private readonly RouteIdentifier _routeIdentifier;
     
     /// <summary>
     /// Create a new route planner with a list of available routes.
@@ -18,8 +17,7 @@ public class JourneyPlanner : IJourneyPlanner
     /// <param name="routes">List of possible routes a journey can take</param>
     public JourneyPlanner(List<Route> routes)
     {
-        _routes = routes;
-        _routeIdentifier = new RouteIdentifier(_routes);
+        _routeIdentifier = new RouteIdentifier(routes);
     }
     
     /// <summary>
@@ -42,6 +40,12 @@ public class JourneyPlanner : IJourneyPlanner
     }
 
 
+    /// <summary>
+    /// Plans a journey where it is known an interchange is not required.
+    /// </summary>
+    /// <param name="origin">Start of journey</param>
+    /// <param name="destination">End of journey</param>
+    /// <returns>Planned journey without an interchange between origin and destination stops</returns>
     private PlannedJourney PlanJourneyWithoutInterchange(Stop origin, Stop destination)
     {
         var originRoutes = _routeIdentifier.IdentifyRoutesBetween(origin, destination);
@@ -61,6 +65,13 @@ public class JourneyPlanner : IJourneyPlanner
         };
     }
     
+    /// <summary>
+    /// Plans a journey where it is known an interchange is required.
+    /// This identifies and handles the interchange stop.
+    /// </summary>
+    /// <param name="origin">Start of journey</param>
+    /// <param name="destination">End of journey</param>
+    /// <returns>Journey information including relevant </returns>
     private PlannedJourney PlanJourneyWithInterchange(Stop origin, Stop destination)
     {
         var interchangeStop = _routeIdentifier.IdentifyInterchangeStop(origin, destination);

--- a/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
@@ -6,13 +6,13 @@ namespace TfGM_API_Wrapper.Models.RoutePlanner;
 /// <summary>
 /// Plans routes between Stop objects.
 /// </summary>
-public class RoutePlanner : IRoutePlanner
+public class JourneyPlanner : IJourneyPlanner
 {
     /// <summary>
     /// Create a new route planner with a list of available routes.
     /// </summary>
     /// <param name="routes">List of possible routes a journey can take</param>
-    public RoutePlanner(List<Route> routes)
+    public JourneyPlanner(List<Route> routes)
     {
         
     }
@@ -23,8 +23,14 @@ public class RoutePlanner : IRoutePlanner
     /// <param name="origin">Start of journey</param>
     /// <param name="destination">End of Journey</param>
     /// <returns>List of possible Planned Routes</returns>
-    public List<PlannedRoute> FindRoute(Stop origin, Stop destination)
+    public PlannedJourney PlanJourney(Stop origin, Stop destination)
     {
-        return new List<PlannedRoute>();
+        var purpleRoute = new Route("Purple", "", new List<Stop>());
+        var greenRoute = new Route("Green", "", new List<Stop>());
+        var routesFromOrigin = new List<Route> {purpleRoute, greenRoute};
+        return new PlannedJourney
+        {
+            RoutesFromOrigin = routesFromOrigin
+        };
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/JourneyPlanner.cs
@@ -8,13 +8,17 @@ namespace TfGM_API_Wrapper.Models.RoutePlanner;
 /// </summary>
 public class JourneyPlanner : IJourneyPlanner
 {
+    private List<Route> _routes;
+    private RouteIdentifier _routeIdentifier;
+    
     /// <summary>
     /// Create a new route planner with a list of available routes.
     /// </summary>
     /// <param name="routes">List of possible routes a journey can take</param>
     public JourneyPlanner(List<Route> routes)
     {
-        
+        _routes = routes;
+        _routeIdentifier = new RouteIdentifier(_routes);
     }
     
     /// <summary>
@@ -27,10 +31,15 @@ public class JourneyPlanner : IJourneyPlanner
     {
         var purpleRoute = new Route("Purple", "", new List<Stop>());
         var greenRoute = new Route("Green", "", new List<Stop>());
+        var yellowRoute = new Route("Yellow", "", new List<Stop>());
         var routesFromOrigin = new List<Route> {purpleRoute, greenRoute};
+        var routesFromInterchange = new List<Route> {greenRoute, yellowRoute};
+        var isInterchangeRequired = _routeIdentifier.IsInterchangeRequired(origin, destination);
         return new PlannedJourney
         {
-            RoutesFromOrigin = routesFromOrigin
+            RoutesFromOrigin = routesFromOrigin,
+            RoutesFromInterchange = routesFromInterchange,
+            RequiresInterchange = isInterchangeRequired
         };
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using TfGM_API_Wrapper.Models.Stops;
 
 namespace TfGM_API_Wrapper.Models.RoutePlanner;
@@ -5,7 +6,7 @@ namespace TfGM_API_Wrapper.Models.RoutePlanner;
 /// <summary>
 /// POCO object that details a planned route between an origin and destination stop.
 /// </summary>
-public class PlannedRoute
+public class PlannedJourney
 {
     /// <summary>
     /// Stop the route originates / starts at.
@@ -24,18 +25,18 @@ public class PlannedRoute
     public Stop InterchangeStop { get; set; }
     
     /// <summary>
-    /// Route taken from the origin destination
+    /// Routes taken from the origin destination
     /// to either the interchange stop or destination
     /// stop if no interchange is required
-    /// (Only require a single route) .
+    /// (Only require a single route).
     /// </summary>
-    public Route RouteFromOrigin { get; set; }
+    public List<Route> RoutesFromOrigin { get; set; }
     
     /// <summary>
     /// Route from the Interchange stop to the
     /// destination stop. This may be null.
     /// </summary>
-    public Route RouteFromInterchange { get; set; }
+    public List<Route> RoutesFromInterchange { get; set; }
     
     /// <summary>
     /// Boolean showing if the route requires an

--- a/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
@@ -33,11 +33,16 @@ public class PlannedJourney
     public List<Route> RoutesFromOrigin { get; set; }
     
     /// <summary>
+    /// Stops between the origin stop and interchange or destination for each route.
+    /// </summary>
+    public List<Stop> StopsFromOrigin { get; set; }
+    
+    /// <summary>
     /// Maps the route name to the destination of the Tram to the Interchange Stop or the Destination Stop
     /// E.g.Green line towards Bury (With the Stop value for Bury)
     /// </summary>
-    public Dictionary<string, Stop> DestinationsFromOrigin { get; set; }
-    
+    public HashSet<Stop> TerminiFromOrigin { get; set; }
+
     /// <summary>
     /// Route from the Interchange stop to the
     /// destination stop. This may be null.
@@ -45,10 +50,16 @@ public class PlannedJourney
     public List<Route> RoutesFromInterchange { get; set; }
     
     /// <summary>
+    /// Stops between the interchange and destination stop.
+    /// </summary>
+    public List<Stop> StopsFromInterchange { get; set; }
+    
+    /// <summary>
     /// Maps the route name to the destination of the Tram from the interchange stop.
     /// E.g.Green line towards Bury (With the Stop value for Bury)
     /// </summary>
-    public Dictionary<string, Stop> DestinationsFromInterchange { get; set; }
+    public HashSet<Stop> TerminiFromInterchange { get; set; }
+    
     
     /// <summary>
     /// Boolean showing if the route requires an

--- a/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/PlannedJourney.cs
@@ -33,10 +33,22 @@ public class PlannedJourney
     public List<Route> RoutesFromOrigin { get; set; }
     
     /// <summary>
+    /// Maps the route name to the destination of the Tram to the Interchange Stop or the Destination Stop
+    /// E.g.Green line towards Bury (With the Stop value for Bury)
+    /// </summary>
+    public Dictionary<string, Stop> DestinationsFromOrigin { get; set; }
+    
+    /// <summary>
     /// Route from the Interchange stop to the
     /// destination stop. This may be null.
     /// </summary>
     public List<Route> RoutesFromInterchange { get; set; }
+    
+    /// <summary>
+    /// Maps the route name to the destination of the Tram from the interchange stop.
+    /// E.g.Green line towards Bury (With the Stop value for Bury)
+    /// </summary>
+    public Dictionary<string, Stop> DestinationsFromInterchange { get; set; }
     
     /// <summary>
     /// Boolean showing if the route requires an

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -83,4 +83,18 @@ public class RouteIdentifier
         var interchangeStop = stopDistanceFromDestination.MinBy(kvp => kvp.Value).Key;
         return interchangeStop;
     }
+
+    /// <summary>
+    /// Identifies the Routes that connect two stops.
+    /// This returns a list of routes that can be taken between two stops.
+    /// </summary>
+    /// <param name="origin">Start of journey</param>
+    /// <param name="destination">End of journey</param>
+    /// <returns>Routes that link the two stops</returns>
+    public List<Route> IdentifyRoutesBetween(Stop origin, Stop destination)
+    {
+        var purpleRoute = new Route("Purple", "", new List<Stop>());
+        var greenRoute = new Route("Green", "", new List<Stop>());
+        return new List<Route>{purpleRoute, greenRoute};
+    }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -5,10 +5,18 @@ using TfGM_API_Wrapper.Models.Stops;
 
 namespace TfGM_API_Wrapper.Models.RoutePlanner;
 
+/// <summary>
+/// Identifies Route related features for journeys such as interchanges.
+/// </summary>
 public class RouteIdentifier
 {
     private readonly List<Route> _routes;
     
+    /// <summary>
+    /// Initialises a RouteIdentifier with the routes
+    /// to use for processing. 
+    /// </summary>
+    /// <param name="routes">Routes to use for processing.</param>
     public RouteIdentifier(List<Route> routes)
     {
         _routes = routes;

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -115,6 +115,9 @@ public class RouteIdentifier
 
         if (destination is null)
             throw new ArgumentNullException(nameof(destination));
+
+        if (route is null)
+            throw new ArgumentNullException(nameof(route));
         
         if (!route.Stops.Contains(origin))
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -99,4 +99,21 @@ public class RouteIdentifier
             throw new ArgumentNullException(nameof(destination));
         return _routes.FindAll(route => route.ContainsStop(origin) && route.ContainsStop(destination));
     }
+
+    /// <summary>
+    /// Identifies Stops between an Origin and Destination stop.
+    /// This excludes the origin and destination stop.
+    /// </summary>
+    /// <param name="origin">Stop to start at.</param>
+    /// <param name="destination">Stop to end at.</param>
+    /// <param name="route">Route to identify intermediate stops on.</param>
+    /// <returns>List of intermediate stops between origin and destination on given route.</returns>
+    public List<Stop> IdentifyIntermediateStops(Stop origin, Stop destination, Route route)
+    {
+        var createdStop = new Stop()
+        {
+            StopName = "Navigation Road"
+        };
+        return new List<Stop> {createdStop};
+    }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -17,11 +17,13 @@ public class RouteIdentifier
     /// by checking to see if there is a route that contains
     /// both the origin and destination stop.
     /// </summary>
-    /// <param name="origin"></param>
-    /// <param name="destination"></param>
-    /// <returns></returns>
+    /// <param name="origin">Start of journey</param>
+    /// <param name="destination">End of journey</param>
+    /// <returns>If there is route that contains both Stops</returns>
     public bool IsInterchangeRequired(Stop origin, Stop destination)
     {
-        return false;
+        //Returns true if there is a route that contains both origin and dest stops.
+        //Find returns null if there is not a match, so interchange is required if there is not a match
+        return _routes.Find(route => route.Stops.Contains(origin) && route.Stops.Contains(destination)) is null;
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -165,6 +165,8 @@ public class RouteIdentifier
         
         if (!route.Stops.Contains(origin))
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
+        if (!route.Stops.Contains(destination))
+            throw new InvalidOperationException(destination.StopName + " does not exist on " + route.Name + " route");
 
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -113,6 +113,9 @@ public class RouteIdentifier
         if (!route.Stops.Contains(origin))
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
         
+        if (!route.Stops.Contains(destination))
+            throw new InvalidOperationException(destination.StopName + " does not exist on " + route.Name + " route");
+        
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);
         var increment = destinationIndex > originIndex ? 1 : -1;

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -93,8 +93,6 @@ public class RouteIdentifier
     /// <returns>Routes that link the two stops</returns>
     public List<Route> IdentifyRoutesBetween(Stop origin, Stop destination)
     {
-        var purpleRoute = new Route("Purple", "", new List<Stop>());
-        var greenRoute = new Route("Green", "", new List<Stop>());
-        return new List<Route>{purpleRoute, greenRoute};
+        return _routes.FindAll(route => route.ContainsStop(origin) && route.ContainsStop(destination));
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -110,6 +110,9 @@ public class RouteIdentifier
     /// <returns>List of intermediate stops between origin and destination on given route.</returns>
     public List<Stop> IdentifyIntermediateStops(Stop origin, Stop destination, Route route)
     {
+        if (origin is null)
+            throw new ArgumentNullException(nameof(origin));
+        
         if (!route.Stops.Contains(origin))
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
         

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -112,6 +112,9 @@ public class RouteIdentifier
     {
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
+
+        if (destination is null)
+            throw new ArgumentNullException(nameof(destination));
         
         if (!route.Stops.Contains(origin))
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -174,10 +174,9 @@ public class RouteIdentifier
     /// <param name="origin">Origin Stop to validate</param>
     /// <param name="destination">Destination Stop to validate</param>
     /// <param name="route">Route to validate the Stops exist on</param>
-    /// <returns>True if the Stops are valid with the given route</returns>
     /// <exception cref="ArgumentNullException">Thrown if any argument is null</exception>
     /// <exception cref="InvalidOperationException">Thrown if either of the stops do not exist on the provided route</exception>
-    private static bool ValidateStopsOnRoute(Stop origin, Stop destination, Route route)
+    private static void ValidateStopsOnRoute(Stop origin, Stop destination, Route route)
     {
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
@@ -190,7 +189,5 @@ public class RouteIdentifier
             throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
         if (!route.Stops.Contains(destination))
             throw new InvalidOperationException(destination.StopName + " does not exist on " + route.Name + " route");
-
-        return true;
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -162,6 +162,9 @@ public class RouteIdentifier
             throw new ArgumentNullException(nameof(destination));
         if (route is null)
             throw new ArgumentNullException(nameof(route));
+        
+        if (!route.Stops.Contains(origin))
+            throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
 
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -110,6 +110,9 @@ public class RouteIdentifier
     /// <returns>List of intermediate stops between origin and destination on given route.</returns>
     public List<Stop> IdentifyIntermediateStops(Stop origin, Stop destination, Route route)
     {
+        if (!route.Stops.Contains(origin))
+            throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
+        
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);
         var increment = destinationIndex > originIndex ? 1 : -1;

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -156,9 +156,8 @@ public class RouteIdentifier
     /// <returns>Terminus Stop for the route direction</returns>
     public Stop IdentifyRouteTerminus(Stop origin, Stop destination, Route route)
     {
-        return new Stop
-        {
-            StopName = "Altrincham"
-        };
+        var originIndex = route.Stops.IndexOf(origin);
+        var destinationIndex = route.Stops.IndexOf(destination);
+        return destinationIndex > originIndex ? route.Stops.Last() : route.Stops.First();
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -53,6 +53,9 @@ public class RouteIdentifier
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
 
+        if (destination is null)
+            throw new ArgumentNullException(nameof(destination));
+
         //Identify the routes for a stop.
         var originRoutes = _routes.FindAll(route => route.ContainsStop(origin));
         var destRoutes = _routes.FindAll(route => route.ContainsStop(destination));

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -95,6 +95,8 @@ public class RouteIdentifier
     {
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
+        if (destination is null)
+            throw new ArgumentNullException(nameof(destination));
         return _routes.FindAll(route => route.ContainsStop(origin) && route.ContainsStop(destination));
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -50,6 +50,9 @@ public class RouteIdentifier
         // as it is a hub and spokes network, where the central section (Cornbrook to St Peters Square)
         // acts as the hub.
 
+        if (origin is null)
+            throw new ArgumentNullException(nameof(origin));
+
         //Identify the routes for a stop.
         var originRoutes = _routes.FindAll(route => route.ContainsStop(origin));
         var destRoutes = _routes.FindAll(route => route.ContainsStop(destination));

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -26,6 +26,9 @@ public class RouteIdentifier
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
         
+        if (destination is null)
+            throw new ArgumentNullException(nameof(destination));
+        
         //Returns true if there is a route that contains both origin and dest stops.
         //Find returns null if there is not a match, so interchange is required if there is not a match
         return _routes.Find(route => route.Stops.Contains(origin) && route.Stops.Contains(destination)) is null;

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -110,10 +110,16 @@ public class RouteIdentifier
     /// <returns>List of intermediate stops between origin and destination on given route.</returns>
     public List<Stop> IdentifyIntermediateStops(Stop origin, Stop destination, Route route)
     {
-        var createdStop = new Stop()
+        var originIndex = route.Stops.IndexOf(origin);
+        var destinationIndex = route.Stops.IndexOf(destination);
+        var increment = destinationIndex > originIndex ? 1 : -1;
+
+        var intermediateStops = new List<Stop>();
+        for (var i = originIndex + increment; i != destinationIndex; i += increment)
         {
-            StopName = "Navigation Road"
-        };
-        return new List<Stop> {createdStop};
+            intermediateStops.Add(route.Stops[i]);
+        }
+
+        return intermediateStops;
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using TfGM_API_Wrapper.Models.Stops;
 
@@ -22,6 +23,9 @@ public class RouteIdentifier
     /// <returns>If there is route that contains both Stops</returns>
     public bool IsInterchangeRequired(Stop origin, Stop destination)
     {
+        if (origin is null)
+            throw new ArgumentNullException(nameof(origin));
+        
         //Returns true if there is a route that contains both origin and dest stops.
         //Find returns null if there is not a match, so interchange is required if there is not a match
         return _routes.Find(route => route.Stops.Contains(origin) && route.Stops.Contains(destination)) is null;

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -156,6 +156,13 @@ public class RouteIdentifier
     /// <returns>Terminus Stop for the route direction</returns>
     public Stop IdentifyRouteTerminus(Stop origin, Stop destination, Route route)
     {
+        if (origin is null)
+            throw new ArgumentNullException(nameof(origin));
+        if (destination is null)
+            throw new ArgumentNullException(nameof(destination));
+        if (route is null)
+            throw new ArgumentNullException(nameof(route));
+
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);
         return destinationIndex > originIndex ? route.Stops.Last() : route.Stops.First();

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -145,4 +145,20 @@ public class RouteIdentifier
 
         return intermediateStops;
     }
+
+    /// <summary>
+    /// Identifies the correct terminus of a route depending on the]
+    /// direction of travel between the origin and destination stops.
+    /// </summary>
+    /// <param name="origin">Origin of journey on route</param>
+    /// <param name="destination">Destination of journey on route</param>
+    /// <param name="route">Route travelling on</param>
+    /// <returns>Terminus Stop for the route direction</returns>
+    public Stop IdentifyRouteTerminus(Stop origin, Stop destination, Route route)
+    {
+        return new Stop
+        {
+            StopName = "Altrincham"
+        };
+    }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -93,6 +93,8 @@ public class RouteIdentifier
     /// <returns>Routes that link the two stops</returns>
     public List<Route> IdentifyRoutesBetween(Stop origin, Stop destination)
     {
+        if (origin is null)
+            throw new ArgumentNullException(nameof(origin));
         return _routes.FindAll(route => route.ContainsStop(origin) && route.ContainsStop(destination));
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -135,20 +135,7 @@ public class RouteIdentifier
     /// <returns>List of intermediate stops between origin and destination on given route.</returns>
     public List<Stop> IdentifyIntermediateStops(Stop origin, Stop destination, Route route)
     {
-        if (origin is null)
-            throw new ArgumentNullException(nameof(origin));
-
-        if (destination is null)
-            throw new ArgumentNullException(nameof(destination));
-
-        if (route is null)
-            throw new ArgumentNullException(nameof(route));
-        
-        if (!route.Stops.Contains(origin))
-            throw new InvalidOperationException(origin.StopName + " does not exist on " + route.Name + " route");
-        
-        if (!route.Stops.Contains(destination))
-            throw new InvalidOperationException(destination.StopName + " does not exist on " + route.Name + " route");
+        ValidateStopsOnRoute(origin, destination, route);
         
         var originIndex = route.Stops.IndexOf(origin);
         var destinationIndex = route.Stops.IndexOf(destination);
@@ -173,6 +160,25 @@ public class RouteIdentifier
     /// <returns>Terminus Stop for the route direction</returns>
     public Stop IdentifyRouteTerminus(Stop origin, Stop destination, Route route)
     {
+        ValidateStopsOnRoute(origin, destination, route);
+
+        var originIndex = route.Stops.IndexOf(origin);
+        var destinationIndex = route.Stops.IndexOf(destination);
+        return destinationIndex > originIndex ? route.Stops.Last() : route.Stops.First();
+    }
+
+    /// <summary>
+    /// Validates the stops being used on the given route.
+    /// This returns true if the stops are both valid and exist on the provided route.
+    /// </summary>
+    /// <param name="origin">Origin Stop to validate</param>
+    /// <param name="destination">Destination Stop to validate</param>
+    /// <param name="route">Route to validate the Stops exist on</param>
+    /// <returns>True if the Stops are valid with the given route</returns>
+    /// <exception cref="ArgumentNullException">Thrown if any argument is null</exception>
+    /// <exception cref="InvalidOperationException">Thrown if either of the stops do not exist on the provided route</exception>
+    private static bool ValidateStopsOnRoute(Stop origin, Stop destination, Route route)
+    {
         if (origin is null)
             throw new ArgumentNullException(nameof(origin));
         if (destination is null)
@@ -185,8 +191,6 @@ public class RouteIdentifier
         if (!route.Stops.Contains(destination))
             throw new InvalidOperationException(destination.StopName + " does not exist on " + route.Name + " route");
 
-        var originIndex = route.Stops.IndexOf(origin);
-        var destinationIndex = route.Stops.IndexOf(destination);
-        return destinationIndex > originIndex ? route.Stops.Last() : route.Stops.First();
+        return true;
     }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/RouteIdentifier.cs
@@ -33,4 +33,24 @@ public class RouteIdentifier
         //Find returns null if there is not a match, so interchange is required if there is not a match
         return _routes.Find(route => route.Stops.Contains(origin) && route.Stops.Contains(destination)) is null;
     }
+
+    /// <summary>
+    /// Identifies the Interchange Stop for Stops where
+    /// the interchange stop belongs to a route available from the Origin Stop,
+    /// and also belongs to a route that belongs to the Destination Stop.
+    /// </summary>
+    /// <param name="origin"></param>
+    /// <param name="destination"></param>
+    /// <returns></returns>
+    public Stop IdentifyInterchangeStop(Stop origin, Stop destination)
+    {
+        // N.b. We can take this approach as there is nowhere on the metrolink network that
+        // you can go between that cant be completed with a max of 1 interchange, 
+        // as it is a hub and spokes network, where the central section (Cornbrook to St Peters Square)
+        // acts as the hub.
+        return new Stop()
+        {
+            StopName = "Piccadilly"
+        };
+    }
 }

--- a/TfGM-API-Wrapper/Resources/routes.json
+++ b/TfGM-API-Wrapper/Resources/routes.json
@@ -24,7 +24,7 @@
       "Bowker Vale",
       "Heaton Park",
       "Prestwich",
-      "Besses o' th' Barn",
+      "Besses O' Th' Barn",
       "Whitefield",
       "Radcliffe",
       "Bury"
@@ -85,33 +85,13 @@
     ]
   },
   {
-    "RouteName": "Orange",
-    "Colour": "#F18800",
-    "Stops": [
-      "Etihad Campus",
-      "Holt Town",
-      "New Islington",
-      "Piccadilly",
-      "Piccadilly Gardens",
-      "St Peter's Square",
-      "Deansgate - Castlefield",
-      "Cornbrook",
-      "Pomona",
-      "Exchange Quay",
-      "Salford Quays",
-      "Anchorage",
-      "Harbour City",
-      "MediaCityUK"
-    ]
-  },
-  {
     "RouteName": "Yellow",
     "Colour": "#EFBB00",
     "Stops": [
       "Bury",
       "Radcliffe",
       "Whitefield",
-      "Besses o' th' Barn",
+      "Besses O' Th' Barn",
       "Prestwich",
       "Heaton Park",
       "Bowker Vale",
@@ -237,7 +217,8 @@
       "Cornbrook",
       "Deansgate - Castlefield",
       "St Peter's Square",
-      "Exchange Square",
+      "Market Street",
+      "Shudehill",
       "Victoria"
     ]
   }


### PR DESCRIPTION
Implements a basic route planner for planning journeys between stops. 

This optimises the interchange stop to be as close to the destination as possible.
If there are multiple stops that are the same distance, the interchange stop is then the stop of these that is closest to the origin,