### PR TITLE
Add routes to resource loader

### DIFF
--- a/TfGM-API-Wrapper-Tests/TestControllers/TestServicesController.cs
+++ b/TfGM-API-Wrapper-Tests/TestControllers/TestServicesController.cs
@@ -23,7 +23,7 @@ public class TestServicesController
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
             TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
             RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"

--- a/TfGM-API-Wrapper-Tests/TestControllers/TestServicesController.cs
+++ b/TfGM-API-Wrapper-Tests/TestControllers/TestServicesController.cs
@@ -23,9 +23,10 @@ public class TestServicesController
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/ValidStopLoader.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
-            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json"
+            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
+            RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"
         };
         _importedResources = new ResourceLoader(_resourcesConfig).ImportResources();
         _requester = new MockServiceRequester();

--- a/TfGM-API-Wrapper-Tests/TestControllers/TestStopsController.cs
+++ b/TfGM-API-Wrapper-Tests/TestControllers/TestStopsController.cs
@@ -22,9 +22,10 @@ public class TestStopsController
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/ValidStopLoader.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
-            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json"
+            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
+            RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"
         };
         _importedResources = new ResourceLoader(_resourcesConfig).ImportResources();
         _stopsDataModel = new StopsDataModel(_importedResources);
@@ -62,8 +63,7 @@ public class TestStopsController
 
     /// <summary>
     ///     Test the length of the returned Stops list.
-    ///     This should be 1, as there is only a single Stop in the
-    ///     StopLoader file.
+    ///     This should be 99.
     /// </summary>
     [Test]
     public void TestGetExpectedStopsCount()
@@ -74,6 +74,6 @@ public class TestStopsController
         var okResult = result as OkObjectResult;
         Assert.IsNotNull(okResult);
         var retrievedStops = okResult!.Value as List<Stop> ?? new List<Stop>();
-        Assert.AreEqual(1, retrievedStops.Count);
+        Assert.AreEqual(99, retrievedStops.Count);
     }
 }

--- a/TfGM-API-Wrapper-Tests/TestControllers/TestStopsController.cs
+++ b/TfGM-API-Wrapper-Tests/TestControllers/TestStopsController.cs
@@ -22,7 +22,7 @@ public class TestStopsController
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
             TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
             RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"

--- a/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestImportedResources.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestImportedResources.cs
@@ -55,4 +55,16 @@ public class TestImportedResources
         Assert.IsNotNull(_importedResources?.TlarefsToIds);
         Assert.AreEqual(0, _importedResources?.TlarefsToIds.Count);
     }
+
+    /// <summary>
+    /// Test to create a new ImportedResources object
+    /// with an empty imported routes.
+    /// This should not be null and the routes list should be empty.
+    /// </summary>
+    [Test]
+    public void TestCreateEmptyImportedRoutes()
+    {
+        Assert.IsNotNull(_importedResources?.ImportedRoutes);
+        Assert.AreEqual(0, _importedResources?.ImportedRoutes.Count);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
@@ -6,9 +6,10 @@ namespace TfGM_API_Wrapper_Tests.TestModels.TestResources;
 
 public class TestResourceLoader
 {
-    private const string StopResourcePathConst = "../../../Resources/ValidStopLoader.json";
+    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/Stops.json";
     private const string StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json";
     private const string TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json";
+    private const string RoutesPath = "../../../Resources/TestRoutePlanner/routes.json";
     private ResourceLoader? _resourceLoader;
     private ResourcesConfig? _validResourcesConfig;
 
@@ -22,7 +23,8 @@ public class TestResourceLoader
         {
             StopResourcePath = StopResourcePathConst,
             StationNamesToTlarefsPath = StationNamesToTlarefsPath,
-            TlarefsToIdsPath = TlarefsToIdsPath
+            TlarefsToIdsPath = TlarefsToIdsPath,
+            RoutesResourcePath = RoutesPath
         };
 
         _resourceLoader = new ResourceLoader(_validResourcesConfig);
@@ -49,7 +51,7 @@ public class TestResourceLoader
         var importedResources = _resourceLoader?.ImportResources();
         Assert.NotNull(importedResources);
         Debug.Assert(importedResources != null, nameof(importedResources) + " != null");
-        Assert.AreEqual(1, importedResources.ImportedStops.Count);
+        Assert.AreEqual(99, importedResources.ImportedStops.Count);
     }
 
     /// <summary>

--- a/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
@@ -79,4 +79,17 @@ public class TestResourceLoader
         Debug.Assert(importedResources != null, nameof(importedResources) + " != null");
         Assert.AreEqual(14, importedResources.TlarefsToIds.Count);
     }
+
+    /// <summary>
+    /// Test to import the routes using the resource loader.
+    /// This should be included in the ImportedResources,
+    /// which should contain 8 routes.
+    /// </summary>
+    [Test]
+    public void TestImportResourcesImportRoutes()
+    {
+        var importedResources = _resourceLoader?.ImportResources();
+        Assert.NotNull(importedResources);
+        Assert.AreEqual(8, importedResources?.ImportedRoutes.Count);
+    }
 }

--- a/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestResources/TestResourceLoader.cs
@@ -6,7 +6,7 @@ namespace TfGM_API_Wrapper_Tests.TestModels.TestResources;
 
 public class TestResourceLoader
 {
-    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/Stops.json";
+    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/stops.json";
     private const string StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json";
     private const string TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json";
     private const string RoutesPath = "../../../Resources/TestRoutePlanner/routes.json";

--- a/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServiceProcessor.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServiceProcessor.cs
@@ -11,7 +11,7 @@ namespace TfGM_API_Wrapper_Tests.TestModels.TestServices;
 /// </summary>
 public class TestServiceProcessor
 {
-    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/Stops.json";
+    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/stops.json";
     private const string StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json";
     private const string TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json";
     private const string RoutesPath = "../../../Resources/TestRoutePlanner/routes.json";

--- a/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServiceProcessor.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServiceProcessor.cs
@@ -11,9 +11,10 @@ namespace TfGM_API_Wrapper_Tests.TestModels.TestServices;
 /// </summary>
 public class TestServiceProcessor
 {
-    private const string StopResourcePathConst = "../../../Resources/ValidStopLoader.json";
+    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/Stops.json";
     private const string StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json";
     private const string TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json";
+    private const string RoutesPath = "../../../Resources/TestRoutePlanner/routes.json";
     private ImportedResources? _importedResources;
     private MockServiceRequester? _mockServiceRequester;
 
@@ -28,7 +29,8 @@ public class TestServiceProcessor
         {
             StopResourcePath = StopResourcePathConst,
             StationNamesToTlarefsPath = StationNamesToTlarefsPath,
-            TlarefsToIdsPath = TlarefsToIdsPath
+            TlarefsToIdsPath = TlarefsToIdsPath,
+            RoutesResourcePath = RoutesPath
         };
 
         _resourceLoader = new ResourceLoader(_validResourcesConfig);

--- a/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServicesDataModel.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServicesDataModel.cs
@@ -18,7 +18,7 @@ public class TestServicesDataModel
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
             TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
             RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"

--- a/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServicesDataModel.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestServices/TestServicesDataModel.cs
@@ -18,9 +18,10 @@ public class TestServicesDataModel
     {
         _resourcesConfig = new ResourcesConfig
         {
-            StopResourcePath = "../../../Resources/ValidStopLoader.json",
+            StopResourcePath = "../../../Resources/TestRoutePlanner/Stops.json",
             StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json",
-            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json"
+            TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json",
+            RoutesResourcePath = "../../../Resources/TestRoutePlanner/routes.json"
         };
         _importedResources = new ResourceLoader(_resourcesConfig).ImportResources();
         _requester = new MockServiceRequester();

--- a/TfGM-API-Wrapper-Tests/TestModels/TestStops/TestStopLookup.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestStops/TestStopLookup.cs
@@ -12,9 +12,10 @@ namespace TfGM_API_Wrapper_Tests.TestModels.TestStops;
 /// </summary>
 public class TestStopLookup
 {
-    private const string StopResourcePathConst = "../../../Resources/ValidStopLoader.json";
+    private const string StopResourcePathConst = "../../../Resources/TestRoutePlanner/stops.json";
     private const string StationNamesToTlarefsPath = "../../../Resources/Station_Names_to_TLAREFs.json";
     private const string TlarefsToIdsPath = "../../../Resources/TLAREFs_to_IDs.json";
+    private const string RoutePath = "../../../Resources/TestRoutePlanner/routes.json";
 
     private ImportedResources? _importedResources;
 
@@ -33,7 +34,8 @@ public class TestStopLookup
         {
             StopResourcePath = StopResourcePathConst,
             StationNamesToTlarefsPath = StationNamesToTlarefsPath,
-            TlarefsToIdsPath = TlarefsToIdsPath
+            TlarefsToIdsPath = TlarefsToIdsPath,
+            RoutesResourcePath = RoutePath
         };
 
         _resourceLoader = new ResourceLoader(_resourcesConfig);

--- a/TfGM-API-Wrapper/Models/Resources/ImportedResources.cs
+++ b/TfGM-API-Wrapper/Models/Resources/ImportedResources.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TfGM_API_Wrapper.Models.RoutePlanner;
 using TfGM_API_Wrapper.Models.Stops;
 
 namespace TfGM_API_Wrapper.Models.Resources;
@@ -16,6 +17,7 @@ public class ImportedResources
         ImportedStops = new List<Stop>();
         StationNamesToTlaref = new Dictionary<string, string>();
         TlarefsToIds = new Dictionary<string, List<int>>();
+        ImportedRoutes = new List<Route>();
     }
 
     /// <summary>
@@ -33,4 +35,9 @@ public class ImportedResources
     /// An ID here is usually associated with a passenger information display.
     /// </summary>
     public Dictionary<string, List<int>> TlarefsToIds { get; init; }
+    
+    /// <summary>
+    /// Stores routes imported into the application, used in route planning.
+    /// </summary>
+    public List<Route> ImportedRoutes { get; init; }
 }

--- a/TfGM-API-Wrapper/Models/Resources/ResourceLoader.cs
+++ b/TfGM-API-Wrapper/Models/Resources/ResourceLoader.cs
@@ -8,6 +8,7 @@ public class ResourceLoader
     private readonly StationNamesToTlarefLoader _stationNamesToTlarefLoader;
     private readonly StopLoader _stopLoader;
     private readonly TlarefToIdsLoader _tlarefToIdsLoader;
+    private readonly ResourcesConfig _config;
 
     /// <summary>
     /// Creates a new resources loader using the given resources configuration.
@@ -16,6 +17,7 @@ public class ResourceLoader
     /// <param name="resourcesConfig">Resource config used for importing resources</param>
     public ResourceLoader(ResourcesConfig resourcesConfig)
     {
+        _config = resourcesConfig;
         _stopLoader = new StopLoader(resourcesConfig);
         _stationNamesToTlarefLoader = new StationNamesToTlarefLoader(resourcesConfig);
         _tlarefToIdsLoader = new TlarefToIdsLoader(resourcesConfig);
@@ -27,11 +29,14 @@ public class ResourceLoader
     /// <returns>ImportedResources for the system</returns>
     public ImportedResources ImportResources()
     {
+        var importedStops = _stopLoader.ImportStops();
+        var routeLoader = new RouteLoader(_config, importedStops);
         return new ImportedResources
         {
             ImportedStops = _stopLoader.ImportStops(),
             StationNamesToTlaref = _stationNamesToTlarefLoader.ImportStationNamesToTlarefs(),
-            TlarefsToIds = _tlarefToIdsLoader.ImportTlarefsToIds()
+            TlarefsToIds = _tlarefToIdsLoader.ImportTlarefsToIds(),
+            ImportedRoutes = routeLoader.ImportRoutes()
         };
     }
 }

--- a/TfGM-API-Wrapper/appSettings.json
+++ b/TfGM-API-Wrapper/appSettings.json
@@ -2,7 +2,8 @@
     "Resources": {
         "StopResourcePath": "Resources/Stops.json",
         "StationNamesToTlarefsPath": "Resources/Station_Names_to_TLAREFs.json",
-        "TlarefsToIdsPath": "Resources/TLAREFs_to_IDs.json"
+        "TlarefsToIdsPath": "Resources/TLAREFs_to_IDs.json",
+        "RoutesResourcePath": "Resources/routes.json"
     },
     "Logging": {
         "LogLevel": {


### PR DESCRIPTION
Routes are now imported on program startup, as the Resources Config file has had the Routes Path added.

The relevant tests have been updated to use a valid stops file, alongside the addition of the routes path.