### PR TITLE
51 altrincham to bury journey incorrectly estimated at 2 minutes

### DIFF
--- a/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyTimeFinder.cs
+++ b/TfGM-API-Wrapper-Tests/TestModels/TestRoutePlanner/TestJourneyTimeFinder.cs
@@ -193,4 +193,16 @@ public class TestJourneyTimeFinder
                     "Bury", null);
             });
     }
+    
+    /// <summary>
+    /// Test to identify minutes between Altrincham and Bury.
+    /// This should return 62 mins.
+    /// </summary>
+    [Test]
+    public void TestIdentifyTimeAltBury()
+    {
+        var result = _journeyTimeFinder?.FindJourneyTime("Green",
+            "Altrincham", "Bury");
+        Assert.AreEqual(62, result);
+    }
 }

--- a/TfGM-API-Wrapper/Models/RoutePlanner/JourneyTimeFinder.cs
+++ b/TfGM-API-Wrapper/Models/RoutePlanner/JourneyTimeFinder.cs
@@ -43,7 +43,7 @@ public class JourneyTimeFinder
             throw new InvalidOperationException($"The destination stop '{destStopName}' was not " +
                                                 $"found on the '{routeName}' route");
         var destinationTimeSpan = selectedRoute[destStopName];
-        var minutesDifference = Math.Abs(originTimeSpan.Subtract(destinationTimeSpan).Minutes);
-        return minutesDifference;
+        var minutesDifference = Math.Abs(originTimeSpan.Subtract(destinationTimeSpan).TotalMinutes);
+        return Convert.ToInt32(minutesDifference);
     }
 }


### PR DESCRIPTION
Add fix for when a journey takes more than an hour.

This previously used .Minutes, and now uses .TotalMinutes and casts back to an Int32.

Previously, if a journey took 1hr 2 mins, this would be returned as 2 mins.
This is now returned as 62 mins.