### PR TITLE
fix: Rename MCUK and Rochdale rail to match those in stops / routes.

### DIFF
--- a/LiveTramsMCR/Resources/route-times.json
+++ b/LiveTramsMCR/Resources/route-times.json
@@ -89,9 +89,9 @@
         "Shaw and Crompton": "19:10:00",
         "Newhey": "19:06:00",
         "Milnrow": "19:04:00",
-        "Kingsway": "19:02:30",
+        "Kingsway Business Park": "19:02:30",
         "Newbold": "19:01:00",
-        "Rochdale Station": "18:57:30",
+        "Rochdale Railway Station": "18:57:30",
         "Rochdale Town Centre": "18:54:00"
     },
     "Blue": {
@@ -117,7 +117,7 @@
         "Salford Quays": "06:39:00",
         "Anchorage": "06:41:00",
         "Harbour City": "06:42:00",
-        "Media CityUK": "06:44:00",
+        "MediaCityUK": "06:44:00",
         "Broadway": "06:48:00",
         "Langworthy": "06:50:00",
         "Weaste": "06:52:00",


### PR DESCRIPTION
Fix stop names for MCUK / Rochdale Railway station to match those in the stops and routes files.