### PR TITLE
fix: Order destnations in services by inc wait time.

### DIFF
--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
@@ -18,6 +18,7 @@ public class TestFormattedServices
     private Tram? _tram;
     private Tram? _tramDiffDestination;
     private Tram? _tramSameDestinationDiffWait;
+    private Tram? _tramDiffDestinationDiffWait;
     private string? _wait;
 
     [SetUp]
@@ -33,6 +34,7 @@ public class TestFormattedServices
         _tram = new Tram(_destination, _carriages, _status, _wait);
         _tramDiffDestination = new Tram(_diffDestination, _carriages, _status, _wait);
         _tramSameDestinationDiffWait = new Tram(_destination, _diffCarriages, _status, _diffWait);
+        _tramDiffDestinationDiffWait = new Tram(_diffDestination, _diffCarriages, _status, _diffWait);
         _formattedServices = new FormattedServices();
     }
 
@@ -132,6 +134,25 @@ public class TestFormattedServices
         Debug.Assert(second != null, nameof(second) + " != null");
         var secondWait = int.Parse(second.Wait);
         Assert.IsTrue(firstWait < secondWait);
+    }
+
+    /// <summary>
+    /// Test to add multiple trams to diff destinations.
+    /// The destination with the first tram should be displayed first
+    /// </summary>
+    [Test]
+    public void TestValidateDiffDestinationsDiffWait()
+    {
+        _formattedServices?.AddService(_tram);
+        _formattedServices?.AddService(_tramDiffDestinationDiffWait);
+        Dictionary<string, SortedSet<Tram?>?>? result = _formattedServices?.Destinations;
+        Assert.NotNull(result);
+        Debug.Assert(_destination != null, nameof(_destination) + " != null");
+        Assert.IsTrue(result?.ContainsKey(_destination));
+        Debug.Assert(_diffDestination != null, nameof(_diffDestination) + " != null");
+        Assert.IsTrue(result?.ContainsKey(_diffDestination));
+        var firstDestination = result?.Keys.First();
+        Assert.AreEqual(firstDestination, _diffDestination);
     }
 
     /// <summary>

--- a/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
+++ b/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LiveTramsMCR.Models.V1.Services;
 
@@ -12,15 +14,29 @@ public class FormattedServices
     /// </summary>
     public FormattedServices()
     {
-        Destinations = new Dictionary<string, SortedSet<Tram>>();
+        InternalDestinations = new Dictionary<string, SortedSet<Tram>>();
         Messages = new HashSet<string>();
     }
 
     /// <summary>
     /// Dict between destination and a sorted set of trams for that dest
     /// </summary>
-    public Dictionary<string, SortedSet<Tram>> Destinations { get; }
-    
+    public Dictionary<string, SortedSet<Tram>> Destinations
+    {
+        get
+        {
+            return InternalDestinations.OrderBy(dest => int.Parse(dest.Value.First().Wait))
+                .ToDictionary(dest => dest.Key, dest => dest.Value);
+
+        }
+    }
+
+    /// <summary>
+    /// Destinations added internally to the class.
+    /// These are then ordered on the get of destinations
+    /// </summary>
+    private Dictionary<string, SortedSet<Tram>> InternalDestinations { get; set; }
+
     /// <summary>
     /// Service messages for the 
     /// </summary>
@@ -34,10 +50,10 @@ public class FormattedServices
     public void AddService(Tram tram)
     {
         if (tram == null) return;
-        if (!Destinations.ContainsKey(tram.Destination))
-            Destinations[tram.Destination] = new SortedSet<Tram>(new TramComparer());
+        if (!InternalDestinations.ContainsKey(tram.Destination))
+            InternalDestinations[tram.Destination] = new SortedSet<Tram>(new TramComparer());
 
-        Destinations[tram.Destination].Add(tram);
+        InternalDestinations[tram.Destination].Add(tram);
     }
 
     /// <summary>


### PR DESCRIPTION
Order destinations by increasing wait time

This ensures the soonest service is displayed first