### PR TITLE
Add last updated time to services

### DIFF
--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
@@ -192,4 +192,18 @@ public class TestFormattedServices
         Assert.NotNull(_formattedServices?.Messages);
         Assert.AreEqual(0, _formattedServices?.Messages.Count);
     }
+
+    /// <summary>
+    /// Test to check that last updated is set.
+    /// This should be set to match the value given.
+    /// </summary>
+    [Test]
+    public void TestSetLastUpdated()
+    {
+        const string exampleString = "2023-04-19T19:34:03Z";
+        _formattedServices?.SetLastUpdated(exampleString);
+        Assert.NotNull(_formattedServices?.LastUpdated);
+        Assert.IsNotEmpty(_formattedServices?.LastUpdated);
+        Assert.AreEqual(exampleString, _formattedServices?.LastUpdated);
+    }
 }

--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
@@ -20,6 +20,8 @@ public class TestFormattedServices
     private Tram? _tramSameDestinationDiffWait;
     private Tram? _tramDiffDestinationDiffWait;
     private string? _wait;
+    private const string ExampleLastUpdated = "2023-04-19T19:34:03Z";
+    private const string DiffExampleLastUpdated = "2023-04-19T11:34:03Z";
 
     [SetUp]
     public void SetUp()
@@ -200,11 +202,10 @@ public class TestFormattedServices
     [Test]
     public void TestSetLastUpdated()
     {
-        const string exampleString = "2023-04-19T19:34:03Z";
-        _formattedServices?.SetLastUpdated(exampleString);
+        _formattedServices?.SetLastUpdated(ExampleLastUpdated);
         Assert.NotNull(_formattedServices?.LastUpdated);
         Assert.IsNotEmpty(_formattedServices?.LastUpdated);
-        Assert.AreEqual(exampleString, _formattedServices?.LastUpdated);
+        Assert.AreEqual(ExampleLastUpdated, _formattedServices?.LastUpdated);
     }
 
     /// <summary>
@@ -213,18 +214,28 @@ public class TestFormattedServices
     [Test]
     public void TestSetLastUpdatedNull()
     {
+        _formattedServices?.SetLastUpdated(ExampleLastUpdated);
         _formattedServices?.SetLastUpdated(null);
         Assert.NotNull(_formattedServices?.LastUpdated);
-        Assert.IsEmpty(_formattedServices?.LastUpdated);
+        Assert.AreEqual(ExampleLastUpdated, _formattedServices?.LastUpdated);
     }
 
     [Test]
     public void TestSetLastUpdatedEmpty()
     {
-        const string exampleString = "2023-04-19T19:34:03Z";
-        _formattedServices?.SetLastUpdated(exampleString);
+        _formattedServices?.SetLastUpdated(ExampleLastUpdated);
         _formattedServices?.SetLastUpdated("");
         Assert.NotNull(_formattedServices?.LastUpdated);
         Assert.IsNotEmpty(_formattedServices?.LastUpdated);
+    }
+
+    [Test]
+    public void TestDoNotUpdateLastUpdatedWhenSet()
+    {
+        _formattedServices?.SetLastUpdated(ExampleLastUpdated);
+        _formattedServices?.SetLastUpdated(DiffExampleLastUpdated);
+        Assert.NotNull(_formattedServices?.LastUpdated);
+        Assert.IsNotEmpty(_formattedServices?.LastUpdated);
+        Assert.AreEqual(ExampleLastUpdated, _formattedServices?.LastUpdated);
     }
 }

--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
@@ -217,4 +217,14 @@ public class TestFormattedServices
         Assert.NotNull(_formattedServices?.LastUpdated);
         Assert.IsEmpty(_formattedServices?.LastUpdated);
     }
+
+    [Test]
+    public void TestSetLastUpdatedEmpty()
+    {
+        const string exampleString = "2023-04-19T19:34:03Z";
+        _formattedServices?.SetLastUpdated(exampleString);
+        _formattedServices?.SetLastUpdated("");
+        Assert.NotNull(_formattedServices?.LastUpdated);
+        Assert.IsNotEmpty(_formattedServices?.LastUpdated);
+    }
 }

--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestFormattedServices.cs
@@ -206,4 +206,15 @@ public class TestFormattedServices
         Assert.IsNotEmpty(_formattedServices?.LastUpdated);
         Assert.AreEqual(exampleString, _formattedServices?.LastUpdated);
     }
+
+    /// <summary>
+    /// Test to check that last updated is not set when null is passed.
+    /// </summary>
+    [Test]
+    public void TestSetLastUpdatedNull()
+    {
+        _formattedServices?.SetLastUpdated(null);
+        Assert.NotNull(_formattedServices?.LastUpdated);
+        Assert.IsEmpty(_formattedServices?.LastUpdated);
+    }
 }

--- a/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestServiceFormatter.cs
+++ b/LiveTramsMCR.Tests/TestModels/V1/TestServices/TestServiceFormatter.cs
@@ -203,6 +203,22 @@ public class TestServiceFormatter
     }
 
     /// <summary>
+    /// Test to check the last updated value is set.
+    /// This should be set to that from the first service
+    /// </summary>
+    [Test]
+    public void TestSetLastUpdated()
+    {
+        _unformattedServicesList?.Add(_unformattedServices);
+        var result = _serviceFormatter?.FormatServices(_unformattedServicesList);
+        Assert.NotNull(result);
+        Assert.NotNull(result?.LastUpdated);
+        Assert.IsNotEmpty(result?.LastUpdated);
+        Assert.AreEqual(_unformattedServices?.LastUpdated, result?.LastUpdated);
+    }
+    
+
+    /// <summary>
     /// Test formatting departureBoardServices with valid unformatted services.
     /// </summary>
     [Test]

--- a/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
+++ b/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
@@ -15,6 +15,7 @@ public class FormattedServices
     {
         InternalDestinations = new Dictionary<string, SortedSet<Tram>>();
         Messages = new HashSet<string>();
+        LastUpdated = "";
     }
 
     /// <summary>
@@ -40,6 +41,11 @@ public class FormattedServices
     /// Service messages for the 
     /// </summary>
     public HashSet<string> Messages { get; }
+    
+    /// <summary>
+    /// UTC Time string of when the service information was last updated
+    /// </summary>
+    public string LastUpdated { get; private set; }
 
     /// <summary>
     ///     Adds a tram to the formatted services.
@@ -63,5 +69,15 @@ public class FormattedServices
     {
         if (message == null) return;
         Messages.Add(message);
+    }
+
+    /// <summary>
+    /// Update the last updated value
+    /// This is not updated after initially being set
+    /// </summary>
+    /// <param name="lastUpdated"></param>
+    public void SetLastUpdated(string lastUpdated)
+    {
+        LastUpdated = lastUpdated;
     }
 }

--- a/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
+++ b/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
@@ -78,7 +78,7 @@ public class FormattedServices
     /// <param name="lastUpdated"></param>
     public void SetLastUpdated(string lastUpdated)
     {
-        if (lastUpdated == null) return;
+        if (string.IsNullOrEmpty(lastUpdated)) return;
         LastUpdated = lastUpdated;
     }
 }

--- a/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
+++ b/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
@@ -78,6 +78,7 @@ public class FormattedServices
     /// <param name="lastUpdated"></param>
     public void SetLastUpdated(string lastUpdated)
     {
+        if (lastUpdated == null) return;
         LastUpdated = lastUpdated;
     }
 }

--- a/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
+++ b/LiveTramsMCR/Models/V1/Services/FormattedServices.cs
@@ -15,7 +15,7 @@ public class FormattedServices
     {
         InternalDestinations = new Dictionary<string, SortedSet<Tram>>();
         Messages = new HashSet<string>();
-        LastUpdated = "";
+        LastUpdated = null;
     }
 
     /// <summary>
@@ -79,6 +79,7 @@ public class FormattedServices
     public void SetLastUpdated(string lastUpdated)
     {
         if (string.IsNullOrEmpty(lastUpdated)) return;
+        if (LastUpdated != null) return;
         LastUpdated = lastUpdated;
     }
 }

--- a/LiveTramsMCR/Models/V1/Services/ServiceFormatter.cs
+++ b/LiveTramsMCR/Models/V1/Services/ServiceFormatter.cs
@@ -32,6 +32,8 @@ public class ServiceFormatter
                 service.Wait3));
 
             FormatMessage(formattedServices, service.MessageBoard);
+            
+            SetLastUpdated(formattedServices, service.LastUpdated);
         }
 
         return formattedServices;
@@ -118,5 +120,11 @@ public class ServiceFormatter
             RegexOptions.None,
             TimeSpan.FromMilliseconds(100)).TrimStart();
         formattedDepartureBoardServices.AddMessage(message);
+    }
+
+    private static void SetLastUpdated(FormattedServices formattedServices, string lastUpdated)
+    {
+        if (string.IsNullOrEmpty(lastUpdated)) return;
+        formattedServices.SetLastUpdated(lastUpdated);
     }
 }


### PR DESCRIPTION
This will return a UTC time string of when the services were last updated. 

This will be useful to see if live service information has been unavailable for a while