### PR TITLE
Use SimpleRouteV2 instead of RouteV2.

### DIFF
--- a/LiveTramsMCR/Models/V2/RoutePlanner/SimpleRouteV2.cs
+++ b/LiveTramsMCR/Models/V2/RoutePlanner/SimpleRouteV2.cs
@@ -10,7 +10,7 @@ namespace LiveTramsMCR.Models.V2.RoutePlanner;
 /// Class that represents a tram route between two Stops.
 /// The stops are included as the Stop class, so all relevant information is available.
 /// </summary>
-public class RouteV2
+public class SimpleRouteV2
 {
     /// <summary>
     /// Object ID used by mongodb
@@ -40,7 +40,7 @@ public class RouteV2
     /// <param name="colour">Route hex colour, e.g. #7B2082</param>
     /// <param name="stops"></param>
     ///
-    public RouteV2(string name, string colour, List<StopKeysV2> stops)
+    public SimpleRouteV2(string name, string colour, List<StopKeysV2> stops)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Colour = colour ?? throw new ArgumentNullException(nameof(colour));

--- a/LiveTramsMCR/Models/V2/Stops/StopV2.cs
+++ b/LiveTramsMCR/Models/V2/Stops/StopV2.cs
@@ -34,7 +34,7 @@ public sealed class StopV2 : IEquatable<StopV2>, IEqualityComparer<StopV2>
     /// <summary>
     /// Routes the stop is on.
     /// </summary>
-    public List<RouteV2> Routes { get; set; }
+    public List<SimpleRouteV2> Routes { get; set; }
     
     /// <summary>
     /// Naptan ID for the stop. This can be used to look up more information


### PR DESCRIPTION
RouteV2 will be used to store more complex information not needed in the stops endpoint.

This differentiation will remove dependencies between the two