### PR TITLE
Improve closest stop identification range.

### DIFF
--- a/LiveTramsMCR/Configuration/Configuration.Routes.cs
+++ b/LiveTramsMCR/Configuration/Configuration.Routes.cs
@@ -5,5 +5,5 @@ internal static partial class Configuration
     /// <summary>
     /// Location tolerance used when comparing coordinates.
     /// </summary>
-    internal static double LocationAccuracyTolerance => 0.000001;
+    internal static double LocationAccuracyTolerance => 0.00000000001;
 }


### PR DESCRIPTION
This decreaes the tolerance to the same resolution as the route / stop location lat / longs.